### PR TITLE
Proposed Ending Event output

### DIFF
--- a/src/ical-events.html
+++ b/src/ical-events.html
@@ -19,7 +19,8 @@
                 }
             },
             inputs: 1,
-            outputs: 1,
+            outputs: 2,
+            outputLabels: ["Start Message","End Message"],
             color: "#E7AE24",
             label: function () {
                 if (this.name) {

--- a/src/ical-events.ts
+++ b/src/ical-events.ts
@@ -3,6 +3,7 @@ import { Red, Node } from 'node-red';
 import * as crypto from "crypto-js";
 import * as  ical from 'node-ical';
 import { CronJob } from 'cron';
+import { CronTime } from 'cron';
 import { CalDav } from './caldav';
 import * as parser from 'cron-parser';
 import { Config } from './ical-config';
@@ -124,11 +125,12 @@ module.exports = function (RED: Red) {
                         var ev = data[k];
 
                         const eventStart = new Date(ev.start);
+                        const eventEnd = new Date(ev.end);
                         if (ev.type == 'VEVENT') {
                             if (eventStart > dateNow) {
-                                let uid = crypto.MD5(ev.start + ev.summary).toString();
+                                let uid = crypto.MD5(ev.created + ev.summary+"start").toString();
                                 if (ev.uid) {
-                                    uid = ev.uid;
+                                    uid = ev.uid+"start";
                                 }
 
                                 const event: CalEvent = {
@@ -146,13 +148,46 @@ module.exports = function (RED: Red) {
                                     eventStart.setMinutes(eventStart.getMinutes() - 1);
                                 }
 
-                                const job2 = new CronJob(eventStart, cronJob.bind(null, event, node));
+                                const job2 = new CronJob(eventStart, cronJobStart.bind(null, event, node));
                                 let startedCronJobs = node.context().get('startedCronJobs') || {};
                                 if (!newCronJobs.has(uid) && !startedCronJobs[uid]) {
                                     newCronJobs.set(uid, job2);
                                     node.debug("new - " + uid);
                                 }
                                 else if (startedCronJobs[uid]) {
+                                    startedCronJobs[uid].setTime(new CronTime(eventStart));
+                                    node.debug("started - " + uid);
+                                }
+                            }
+                            if (eventEnd > dateNow) {
+                                let uid = crypto.MD5(ev.created + ev.summary+"end").toString();
+                                if (ev.uid) {
+                                    uid = ev.uid+"end";
+                                }
+
+                                const event: CalEvent = {
+                                    summary: ev.summary,
+                                    id: uid,
+                                    location: ev.location,
+                                    eventStart: new Date(ev.start),
+                                    eventEnd: new Date(ev.end),
+                                    description: ev.description
+                                }
+
+                                if (config.offset) {
+                                    eventStart.setMinutes(eventEnd.getMinutes() + parseInt(config.offset));
+                                } else {
+                                    eventStart.setMinutes(eventEnd.getMinutes() - 1);
+                                }
+
+                                const job2 = new CronJob(eventEnd, cronJobEnd.bind(null, event, node));
+                                let startedCronJobs = node.context().get('startedCronJobs') || {};
+                                if (!newCronJobs.has(uid) && !startedCronJobs[uid]) {
+                                    newCronJobs.set(uid, job2);
+                                    node.debug("new - " + uid);
+                                }
+                                else if (startedCronJobs[uid]) {
+                                    startedCronJobs[uid].setTime(new CronTime(eventEnd));
                                     node.debug("started - " + uid);
                                 }
                             }
@@ -178,10 +213,16 @@ module.exports = function (RED: Red) {
         });
     }
 
-    function cronJob(event: any, node: Node) {
-        node.send({
+    function cronJobStart(event: any, node: Node) {
+        node.send([{
             payload: event
-        });
+        },null]);
+    }
+
+    function cronJobEnd(event: any, node: Node) {
+        node.send([null,{
+            payload: event
+        }]);
     }
 
     RED.nodes.registerType("ical-events", eventsNode);


### PR DESCRIPTION
This commit adds a second output to the Events Node that fires at the end of the event. To allow for the event to be changed at anytime in the calendar, the uid is constructed here from the ev.created parameter instead of ev.start. The words start and end are appended to the end of the uid. Thus each calendar event has a pair of cron jobs. Lastly, the else if block that checks if a started job already exists updates that job with the new run time.

I'm not normally a javascript developer, so my solution might not be ideal here. Also, I've never used typescript before, so I thought I'd send this your way to get your feedback about the approach before I spend time setting up a new tools to debug and test. Let me know what you think.