### PR TITLE
Fix major memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ical-events",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "NodeRed calender event adapter",
   "author": {
     "name": "naimo84",

--- a/src/nodes/ical-config.ts
+++ b/src/nodes/ical-config.ts
@@ -16,8 +16,7 @@ export interface IcalEventsConfig extends Config {
     name: string,
     id: any,
     type: any,
-    combineResponse: boolean,
-    nodeconfig: any
+    combineResponse: boolean
 }
 
 module.exports = function (RED: any) {

--- a/src/nodes/ical-events.html
+++ b/src/nodes/ical-events.html
@@ -29,7 +29,7 @@
 
                 return "event trigger";
             },
-            icon: "font-awesome/fa-calendar",
+            icon: "font-awesome/fa-calendar-plus-o",
             paletteLabel: "trigger",
             oneditprepare: function () {
 

--- a/src/nodes/ical-sensor.html
+++ b/src/nodes/ical-sensor.html
@@ -26,7 +26,7 @@
 
             return "event sensor";
         },
-        icon: "font-awesome/fa-calendar",
+        icon: "font-awesome/fa-calendar-check-o",
         paletteLabel: "sensor",
         oneditprepare: function () {
             { { prepareIcalEvents } }


### PR DESCRIPTION
In my test bed, I was leaking approximately 1.5% of my RAM per hour.  With the removal of these unused objects and the caching of another object, the leak is reduced to a maximum 0.1% of my RAM per hour.  This 0.1% leak was consistent even when I reduced the entirety of the ical-sensor node (which I used to test with) to completely no-op.  A different investigation should be undertaken to discover why but it was outside the scope of this work.

![image](https://github.com/naimo84/node-red-contrib-ical-events/assets/3893631/d44fa9cb-3ebc-4d99-b12a-cb134f3034a0)
